### PR TITLE
Add hidden content to study oneToOne

### DIFF
--- a/src/main/kotlin/study/nobreak/personalposts/so/domain/SoHiddenContent.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/domain/SoHiddenContent.kt
@@ -1,0 +1,14 @@
+package study.nobreak.personalposts.so.domain
+
+import javax.persistence.*
+
+@Entity
+class SoHiddenContent(
+    @Id
+    @OneToOne
+    @JoinColumn(name="post_id")
+    val post: SoPost,
+    val question: String,
+    val answer: String,
+    val content: String
+)

--- a/src/main/kotlin/study/nobreak/personalposts/so/domain/SoHiddenContent.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/domain/SoHiddenContent.kt
@@ -5,8 +5,10 @@ import javax.persistence.*
 @Entity
 class SoHiddenContent(
     @Id
-    @OneToOne
-    @JoinColumn(name="post_id")
+    val postId: Long? = null,
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
     val post: SoPost,
     val question: String,
     val answer: String,

--- a/src/main/kotlin/study/nobreak/personalposts/so/domain/SoPost.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/domain/SoPost.kt
@@ -1,28 +1,30 @@
 package study.nobreak.personalposts.so.domain
 
 import study.nobreak.personalposts.so.exception.DataConflictException
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.OneToOne
+import javax.persistence.*
 
 @Entity
 data class SoPost(
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
     val title: String,
     val content: String,
 ) {
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "post", cascade = [CascadeType.PERSIST])
     var hiddenContent: SoHiddenContent? = null
         private set
-    
+
     fun addHiddenContent(question: String, answer: String, hiddenContent: String): SoHiddenContent {
         if (this.hiddenContent != null) {
             throw DataConflictException()
         }
-        return SoHiddenContent(this, question, answer, hiddenContent)
-            .also { this.hiddenContent = it }
+        this.hiddenContent = SoHiddenContent(
+            post = this,
+            question = question,
+            answer = answer,
+            content = hiddenContent
+        )
+        return this.hiddenContent!!
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/domain/SoPost.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/domain/SoPost.kt
@@ -1,8 +1,10 @@
 package study.nobreak.personalposts.so.domain
 
+import study.nobreak.personalposts.so.exception.DataConflictException
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
+import javax.persistence.OneToOne
 
 @Entity
 data class SoPost(
@@ -10,5 +12,17 @@ data class SoPost(
     @GeneratedValue
     val id: Long? = null,
     val title: String,
-    val content: String
-)
+    val content: String,
+) {
+    @OneToOne
+    var hiddenContent: SoHiddenContent? = null
+        private set
+    
+    fun addHiddenContent(question: String, answer: String, hiddenContent: String): SoHiddenContent {
+        if (this.hiddenContent != null) {
+            throw DataConflictException()
+        }
+        return SoHiddenContent(this, question, answer, hiddenContent)
+            .also { this.hiddenContent = it }
+    }
+}

--- a/src/main/kotlin/study/nobreak/personalposts/so/exception/DataConflictException.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/exception/DataConflictException.kt
@@ -1,0 +1,8 @@
+package study.nobreak.personalposts.so.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.CONFLICT)
+class DataConflictException: RuntimeException()

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
@@ -6,4 +6,5 @@ interface SoPostService {
     fun addPost(title: String, content: String)
     fun getAllPosts(): List<SoPost>
     fun deletePost(id: Long)
+    fun addHiddenContent(postId: Long, question: String, answer: String, content: String)
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
@@ -2,6 +2,7 @@ package study.nobreak.personalposts.so.service
 
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import study.nobreak.personalposts.so.domain.SoPost
 import study.nobreak.personalposts.so.exception.NoDataFoundException
 import study.nobreak.personalposts.so.repository.SoPostRepository
@@ -26,6 +27,7 @@ class SoPostServiceImpl(
         }
     }
     
+    @Transactional
     override fun addHiddenContent(postId: Long, question: String, answer: String, content: String) {
         soPostRepository.findById(postId)
             .orElseThrow { throw NoDataFoundException() }

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
@@ -5,8 +5,6 @@ import org.springframework.stereotype.Service
 import study.nobreak.personalposts.so.domain.SoPost
 import study.nobreak.personalposts.so.exception.NoDataFoundException
 import study.nobreak.personalposts.so.repository.SoPostRepository
-import study.nobreak.personalposts.so.web.response.SoPostGetResponse
-import study.nobreak.personalposts.so.web.response.SoPostResponseItem
 
 @Service
 class SoPostServiceImpl(
@@ -26,5 +24,11 @@ class SoPostServiceImpl(
         } catch (e: EmptyResultDataAccessException) {
             throw NoDataFoundException()
         }
+    }
+    
+    override fun addHiddenContent(postId: Long, question: String, answer: String, content: String) {
+        soPostRepository.findById(postId)
+            .orElseThrow { throw NoDataFoundException() }
+            .addHiddenContent(question, answer, content)
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
@@ -3,6 +3,7 @@ package study.nobreak.personalposts.so.web
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import study.nobreak.personalposts.so.service.SoPostService
+import study.nobreak.personalposts.so.web.request.SoHiddenContentCreateRequest
 import study.nobreak.personalposts.so.web.request.SoPostCreateRequest
 import study.nobreak.personalposts.so.web.response.SoPostGetResponse
 import study.nobreak.personalposts.so.web.response.SoPostResponseItem
@@ -28,5 +29,13 @@ class SoPostController(
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deletePost(@PathVariable id: Long) {
         return soPostService.deletePost(id)
+    }
+    
+    @PostMapping("/hidden")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addHiddenContent(@RequestBody soHiddenContentCreateRequest: SoHiddenContentCreateRequest) {
+        with(soHiddenContentCreateRequest) {
+            soPostService.addHiddenContent(postId, question, answer, content)
+        }
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoHiddenContentCreateRequest.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoHiddenContentCreateRequest.kt
@@ -1,0 +1,8 @@
+package study.nobreak.personalposts.so.web.request
+
+class SoHiddenContentCreateRequest(
+    val postId: Long,
+    val question: String,
+    val answer: String,
+    val content: String
+)

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
@@ -5,11 +5,17 @@ import study.nobreak.personalposts.so.domain.SoPost
 data class SoPostResponseItem(
     val id: Long,
     val title: String,
-    val content: String
+    val content: String,
+    val hiddenContentQuestion: String
 ) {
     companion object {
         fun fromSoPost(soPost: SoPost): SoPostResponseItem {
-            return SoPostResponseItem(soPost.id!!, soPost.title, soPost.content)
+            return SoPostResponseItem(
+                id = soPost.id!!,
+                title = soPost.title,
+                content = soPost.content,
+                hiddenContentQuestion = soPost.hiddenContent?.question ?: ""
+            )
         }
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
@@ -14,7 +14,7 @@ data class SoPostResponseItem(
                 id = soPost.id!!,
                 title = soPost.title,
                 content = soPost.content,
-                hiddenContentQuestion = soPost.hiddenContent?.question ?: ""
+                hiddenContentQuestion = if (soPost.hiddenContent != null) soPost.hiddenContent!!.question else ""
             )
         }
     }

--- a/src/test/kotlin/study/nobreak/personalposts/so/domain/SoPostTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/domain/SoPostTest.kt
@@ -1,0 +1,52 @@
+package study.nobreak.personalposts.so.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import study.nobreak.personalposts.so.exception.DataConflictException
+import study.nobreak.personalposts.so.mock.mockSoPost
+
+internal class SoPostTest {
+    @Test
+    fun `SoPost class`() {
+        val post =  mockSoPost(1L, "title-1", "content-1")
+        
+        assertEquals(1L, post.id)
+        assertEquals("title-1", post.title)
+        assertEquals("content-1", post.content)
+    }
+    
+    @Test
+    fun `addHiddenContent success`() {
+        val post = mockSoPost(1)
+        val hiddenContent = post.addHiddenContent(
+            question = "question-1",
+            answer = "answer-1",
+            hiddenContent = "content-1"
+        )
+        
+        assertEquals("question-1", hiddenContent.question)
+        assertEquals("answer-1", hiddenContent.answer)
+        assertEquals("content-1", hiddenContent.content)
+        assertEquals(hiddenContent, post.hiddenContent)
+        assertEquals(post, hiddenContent.post)
+    }
+    
+    @Test
+    fun `addHiddenContent throw DataConflictException when data already exists`() {
+        val post = mockSoPost(1)
+        post.addHiddenContent(
+            question = "question-1",
+            answer = "answer-1",
+            hiddenContent = "content-1"
+        )
+        
+        assertThrows<DataConflictException> {
+            post.addHiddenContent(
+                question = "question-1",
+                answer = "answer-1",
+                hiddenContent = "content-1"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/study/nobreak/personalposts/so/mock/MockSoPost.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/mock/MockSoPost.kt
@@ -1,0 +1,23 @@
+package study.nobreak.personalposts.so.mock
+
+import study.nobreak.personalposts.so.domain.SoPost
+
+fun mockSoPost(
+    id: Long,
+    title: String = "mock-title",
+    content: String = "mock-content",
+    hiddenContent: String? = null,
+    question: String? = null,
+    answer: String? = null
+): SoPost {
+    return SoPost(id, title, content)
+        .apply {
+            if ((hiddenContent == null && question == null && answer == null).not()) {
+                this.addHiddenContent(
+                    question = question ?: "",
+                    answer = answer ?: "",
+                    hiddenContent = hiddenContent ?: ""
+                )
+            }
+        }
+}

--- a/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
@@ -1,0 +1,113 @@
+package study.nobreak.personalposts.so.service
+
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.EmptyResultDataAccessException
+import study.nobreak.personalposts.so.domain.SoPost
+import study.nobreak.personalposts.so.exception.DataConflictException
+import study.nobreak.personalposts.so.exception.NoDataFoundException
+import study.nobreak.personalposts.so.mock.mockSoPost
+import study.nobreak.personalposts.so.repository.SoPostRepository
+import java.util.*
+
+internal class SoPostServiceImplTest {
+    private val soPostRepository: SoPostRepository = mockk()
+    private val soPostService: SoPostService = SoPostServiceImpl(soPostRepository)
+    
+    @AfterEach
+    fun afterTests() {
+        unmockkAll()
+    }
+    
+    @Test
+    fun `addPost success`() {
+        every {
+            soPostRepository.save(any())
+        } returns mockSoPost(
+            id = 1,
+            title = "title",
+            content = "content"
+        )
+        
+        soPostService.addPost(title = "title", content = "content")
+        
+        verify { soPostRepository.save(SoPost(title = "title", content = "content")) }
+    }
+    
+    @Test
+    fun `getAllPosts success`() {
+        every {
+            soPostRepository.findAll()
+        } returns listOf(
+            mockSoPost(id = 1, title = "title-1"),
+            mockSoPost(id = 2),
+            mockSoPost(id = 3),
+            mockSoPost(id = 4)
+        )
+        val result = soPostService.getAllPosts()
+        
+        assertEquals(4, result.size)
+        assertEquals("title-1", result[0].title)
+    }
+    
+    @Test
+    fun `deletePost success`() {
+        every {
+            soPostRepository.deleteById(any())
+        } returns Unit
+        
+        soPostService.deletePost(1)
+        
+        verify { soPostRepository.deleteById(1) }
+    }
+    
+    @Test
+    fun `deletePost throw NoDataFoundException when catch EmptyResultDataAccessException`() {
+        every {
+            soPostRepository.deleteById(1)
+        } throws EmptyResultDataAccessException(1)
+        
+        assertThrows<NoDataFoundException> {
+            soPostService.deletePost(1)
+        }
+    }
+    
+    @Test
+    fun `addHiddenContent success`() {
+        val mockPost = spyk(mockSoPost(1, "title", "content"))
+        every {
+            soPostRepository.findById(any())
+        } returns Optional.of(mockPost)
+        
+        soPostService.addHiddenContent(1, "question-1", "answer-1", "content-1")
+        
+        verify { mockPost.addHiddenContent("question-1", "answer-1", "content-1") }
+    }
+    
+    @Test
+    fun `addHiddenContent throw NoDataFoundException when find result is null`() {
+        every {
+            soPostRepository.findById(any())
+        } returns Optional.empty()
+        
+        assertThrows<NoDataFoundException> {
+            soPostService.addHiddenContent(1, "question-1", "answer-1", "content-1")
+        }
+    }
+    
+    @Test
+    fun `addHiddenContent throw DataConflictException when data already exists`() {
+        every {
+            soPostRepository.findById(any())
+        } returns Optional.of(
+            mockSoPost(1, "title", "content", "question", "answer", "content")
+        )
+        
+        assertThrows<DataConflictException> {
+            soPostService.addHiddenContent(1, "question-1", "answer-1", "content-1")
+        }
+    }
+}

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
@@ -11,8 +11,9 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import study.nobreak.personalposts.so.domain.SoPost
+import study.nobreak.personalposts.so.exception.DataConflictException
 import study.nobreak.personalposts.so.exception.NoDataFoundException
+import study.nobreak.personalposts.so.mock.mockSoPost
 import study.nobreak.personalposts.so.service.SoPostService
 
 @WebMvcTest(SoPostController::class)
@@ -26,8 +27,8 @@ internal class SoPostControllerTest {
     @Test
     fun `getPosts success`() {
         every { soPostService.getAllPosts() } returns listOf(
-            SoPost(1, "title-1", "content-1"),
-            SoPost(2, "title-2", "content-2")
+            mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
+            mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
         )
         
         mockMvc.perform(get("/so/posts"))
@@ -35,9 +36,11 @@ internal class SoPostControllerTest {
             .andExpect(jsonPath("$.list[0].id").value("1"))
             .andExpect(jsonPath("$.list[0].title").value("title-1"))
             .andExpect(jsonPath("$.list[0].content").value("content-1"))
+            .andExpect(jsonPath("$.list[0].hiddenContentQuestion").value("hiddenContentQuestion-1"))
             .andExpect(jsonPath("$.list[1].id").value("2"))
             .andExpect(jsonPath("$.list[1].title").value("title-2"))
             .andExpect(jsonPath("$.list[1].content").value("content-2"))
+            .andExpect(jsonPath("$.list[1].hiddenContentQuestion").value("hiddenContentQuestion-2"))
     }
     
     @Test
@@ -72,7 +75,35 @@ internal class SoPostControllerTest {
         mockMvc.perform(
             delete("/so/posts/1")
         ).andExpect(status().isNotFound)
-    
+        
         verify { soPostService.deletePost(1) }
+    }
+    
+    @Test
+    fun `addHiddenContent success`() {
+        every { soPostService.addHiddenContent(any(), any(), any(), any()) } returns Unit
+        
+        mockMvc.perform(
+            post("/so/posts/hidden")
+                .contentType(MediaType.APPLICATION_JSON)
+                //language=json
+                .content("{\n  \"postId\": 1,\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
+        ).andExpect(status().isCreated)
+        
+        verify { soPostService.addHiddenContent(1L, "question-1", "answer-1", "content-1") }
+    }
+    
+    @Test
+    fun `addHiddenContent throw DataConflictException`() {
+        every { soPostService.addHiddenContent(any(), any(), any(), any()) } throws DataConflictException()
+        
+        mockMvc.perform(
+            post("/so/posts/hidden")
+                .contentType(MediaType.APPLICATION_JSON)
+                //language=json
+                .content("{\n  \"postId\": 1,\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
+        ).andExpect(status().isConflict)
+        
+        verify { soPostService.addHiddenContent(1L, "question-1", "answer-1", "content-1") }
     }
 }

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItemTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItemTest.kt
@@ -1,0 +1,36 @@
+package study.nobreak.personalposts.so.web.response
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import study.nobreak.personalposts.so.mock.mockSoPost
+
+internal class SoPostResponseItemTest {
+    @Test
+    fun `fromSoPost`() {
+        val result1 = SoPostResponseItem.fromSoPost(
+            mockSoPost(
+                id = 1L,
+                title = "title-1",
+                content = "content-1"
+            )
+        )
+        val result2 = SoPostResponseItem.fromSoPost(
+            mockSoPost(
+                id = 2L,
+                title = "title-2",
+                content = "content-2",
+                question = "question-2"
+            )
+        )
+        
+        assertEquals(1L, result1.id)
+        assertEquals("title-1", result1.title)
+        assertEquals("content-1", result1.content)
+        assertEquals("", result1.hiddenContentQuestion)
+        
+        assertEquals(2L, result2.id)
+        assertEquals("title-2", result2.title)
+        assertEquals("content-2", result2.content)
+        assertEquals("question-2", result2.hiddenContentQuestion)
+    }
+}


### PR DESCRIPTION
1:1 관계 설정 시 Lazy Loading 동작을 확인 하기 위해 Post에 연결된 HiddenContent를 추가하였습니다.
이 후 작업으로 querydsl을 적용하여 쿼리 최적화를 할 예정입니다.
Controller와 Service, Entity에 테스트를 추가하였습니다.