### PR TITLE
Add get posts with hidden question

### DIFF
--- a/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package study.nobreak.personalposts.so.repository
+
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+import study.nobreak.personalposts.so.domain.QSoPost
+import study.nobreak.personalposts.so.domain.SoPost
+
+@Repository
+class SoPostDslRepositoryImpl: SoPostDslRepository, QuerydslRepositorySupport(SoPost::class.java) {
+    private val soPost: QSoPost = QSoPost.soPost
+    
+    override fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean): List<SoPost> {
+        return if (isHiddenContentIncluded) {
+            from(soPost)
+                .leftJoin(soPost.hiddenContent).fetchJoin()
+                .fetch()
+        } else {
+            from(soPost).fetch()
+        }
+    }
+}

--- a/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostRepository.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostRepository.kt
@@ -3,4 +3,9 @@ package study.nobreak.personalposts.so.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import study.nobreak.personalposts.so.domain.SoPost
 
-interface SoPostRepository: JpaRepository<SoPost, Long>
+interface SoPostRepository: JpaRepository<SoPost, Long>, SoPostDslRepository
+
+interface SoPostDslRepository {
+    fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean): List<SoPost>
+}
+

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
@@ -4,7 +4,7 @@ import study.nobreak.personalposts.so.domain.SoPost
 
 interface SoPostService {
     fun addPost(title: String, content: String)
-    fun getAllPosts(): List<SoPost>
+    fun getAll(isQuestionIncluded: Boolean): List<SoPost>
     fun deletePost(id: Long)
     fun addHiddenContent(postId: Long, question: String, answer: String, content: String)
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
@@ -15,8 +15,8 @@ class SoPostServiceImpl(
         soPostRepository.save(SoPost(title = title, content = content))
     }
     
-    override fun getAllPosts(): List<SoPost> {
-        return soPostRepository.findAll()
+    override fun getAll(isQuestionIncluded: Boolean): List<SoPost> {
+        return soPostRepository.findAllByFetchJoinCondition(isQuestionIncluded)
     }
     
     override fun deletePost(id: Long) {

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
@@ -15,8 +15,9 @@ class SoPostController(
 ) {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    fun getPosts(): SoPostGetResponse {
-        return SoPostGetResponse(soPostService.getAllPosts().map { SoPostResponseItem.fromSoPost(it) })
+    fun getPosts(@RequestParam isQuestionIncluded: Boolean = false): SoPostGetResponse {
+        return SoPostGetResponse(
+            soPostService.getAll(isQuestionIncluded).map { SoPostResponseItem.fromSoPost(it, isQuestionIncluded) })
     }
     
     @PostMapping

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
@@ -31,11 +31,14 @@ class SoPostController(
         return soPostService.deletePost(id)
     }
     
-    @PostMapping("/hidden")
+    @PostMapping("/{id}/hidden-content")
     @ResponseStatus(HttpStatus.CREATED)
-    fun addHiddenContent(@RequestBody soHiddenContentCreateRequest: SoHiddenContentCreateRequest) {
+    fun addHiddenContent(
+        @PathVariable id: Long,
+        @RequestBody soHiddenContentCreateRequest: SoHiddenContentCreateRequest
+    ) {
         with(soHiddenContentCreateRequest) {
-            soPostService.addHiddenContent(postId, question, answer, content)
+            soPostService.addHiddenContent(id, question, answer, content)
         }
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoHiddenContentCreateRequest.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoHiddenContentCreateRequest.kt
@@ -1,7 +1,6 @@
 package study.nobreak.personalposts.so.web.request
 
 class SoHiddenContentCreateRequest(
-    val postId: Long,
     val question: String,
     val answer: String,
     val content: String

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItem.kt
@@ -1,20 +1,27 @@
 package study.nobreak.personalposts.so.web.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import study.nobreak.personalposts.so.domain.SoPost
 
+@JsonInclude(value = Include.NON_NULL)
 data class SoPostResponseItem(
     val id: Long,
     val title: String,
     val content: String,
-    val hiddenContentQuestion: String
+    val hiddenContentQuestion: String?
 ) {
     companion object {
-        fun fromSoPost(soPost: SoPost): SoPostResponseItem {
+        fun fromSoPost(soPost: SoPost, isQuestionIncluded: Boolean): SoPostResponseItem {
             return SoPostResponseItem(
                 id = soPost.id!!,
                 title = soPost.title,
                 content = soPost.content,
-                hiddenContentQuestion = if (soPost.hiddenContent != null) soPost.hiddenContent!!.question else ""
+                hiddenContentQuestion = when {
+                    isQuestionIncluded.not() -> null
+                    soPost.hiddenContent != null -> soPost.hiddenContent!!.question
+                    else -> ""
+                }
             )
         }
     }

--- a/src/test/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImplTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImplTest.kt
@@ -1,0 +1,62 @@
+package study.nobreak.personalposts.so.repository
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.test.context.ActiveProfiles
+import study.nobreak.personalposts.so.domain.SoPost
+
+@DataJpaTest
+@ActiveProfiles("test")
+internal class SoPostDslRepositoryImplTest @Autowired constructor(
+    val entityManager: TestEntityManager,
+    val soPostRepository: SoPostRepository,
+) {
+    @Test
+    fun `findAllByFetchJoinCondition isHiddenContentIncluded true success`() {
+        entityManager.apply {
+            persist(SoPost(title = "title-0", content = "content-0"))
+            persist(SoPost(title = "title-1", content = "content-1").apply {
+                addHiddenContent("question-1", "answer-1", "hidden-content-1")
+            })
+            flush()
+            clear()
+        }
+        val result = soPostRepository.findAllByFetchJoinCondition(true)
+        
+        assertEquals(result.size, 2)
+        assertEquals("title-0", result[0].title)
+        assertEquals("content-0", result[0].content)
+        assertEquals(null, result[0].hiddenContent)
+        assertEquals("title-1", result[1].title)
+        assertEquals("content-1", result[1].content)
+        assertEquals("question-1", result[1].hiddenContent!!.question)
+        assertEquals("answer-1", result[1].hiddenContent!!.answer)
+        assertEquals("hidden-content-1", result[1].hiddenContent!!.content)
+    }
+    
+    @Test
+    fun `findAllByFetchJoinCondition isHiddenContentIncluded false success`() {
+        entityManager.apply {
+            persist(SoPost(title = "title-0", content = "content-0"))
+            persist(SoPost(title = "title-1", content = "content-1").apply {
+                addHiddenContent("question-1", "answer-1", "hidden-content-1")
+            })
+            flush()
+            clear()
+        }
+        val result = soPostRepository.findAllByFetchJoinCondition(false)
+        
+        assertEquals(result.size, 2)
+        assertEquals("title-0", result[0].title)
+        assertEquals("content-0", result[0].content)
+        assertEquals(null, result[0].hiddenContent)
+        assertEquals("title-1", result[1].title)
+        assertEquals("content-1", result[1].content)
+        assertEquals("question-1", result[1].hiddenContent!!.question)
+        assertEquals("answer-1", result[1].hiddenContent!!.answer)
+        assertEquals("hidden-content-1", result[1].hiddenContent!!.content)
+    }
+}

--- a/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
@@ -38,16 +38,16 @@ internal class SoPostServiceImplTest {
     }
     
     @Test
-    fun `getAllPosts success`() {
+    fun `getAll success`() {
         every {
-            soPostRepository.findAll()
+            soPostRepository.findAllByFetchJoinCondition(true)
         } returns listOf(
             mockSoPost(id = 1, title = "title-1"),
             mockSoPost(id = 2),
             mockSoPost(id = 3),
             mockSoPost(id = 4)
         )
-        val result = soPostService.getAllPosts()
+        val result = soPostService.getAll(true)
         
         assertEquals(4, result.size)
         assertEquals("title-1", result[0].title)

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
@@ -26,12 +26,15 @@ internal class SoPostControllerTest {
     
     @Test
     fun `getPosts success`() {
-        every { soPostService.getAllPosts() } returns listOf(
+        every { soPostService.getAll(true) } returns listOf(
             mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
             mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
         )
         
-        mockMvc.perform(get("/so/posts"))
+        mockMvc.perform(
+            get("/so/posts")
+                .param("isQuestionIncluded", "true")
+        )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.list[0].id").value("1"))
             .andExpect(jsonPath("$.list[0].title").value("title-1"))

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
@@ -25,7 +25,7 @@ internal class SoPostControllerTest {
     lateinit var soPostService: SoPostService
     
     @Test
-    fun `getPosts success`() {
+    fun `getPosts isQuestionIncluded true success`() {
         every { soPostService.getAll(true) } returns listOf(
             mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
             mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
@@ -44,6 +44,23 @@ internal class SoPostControllerTest {
             .andExpect(jsonPath("$.list[1].title").value("title-2"))
             .andExpect(jsonPath("$.list[1].content").value("content-2"))
             .andExpect(jsonPath("$.list[1].hiddenContentQuestion").value("hiddenContentQuestion-2"))
+    }
+    
+    @Test
+    fun `getPosts isQuestionIncluded default false success`() {
+        every { soPostService.getAll(false) } returns listOf(
+            mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
+            mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
+        )
+        
+        mockMvc.perform(get("/so/posts"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.list[0].id").value("1"))
+            .andExpect(jsonPath("$.list[0].title").value("title-1"))
+            .andExpect(jsonPath("$.list[0].content").value("content-1"))
+            .andExpect(jsonPath("$.list[1].id").value("2"))
+            .andExpect(jsonPath("$.list[1].title").value("title-2"))
+            .andExpect(jsonPath("$.list[1].content").value("content-2"))
     }
     
     @Test

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
@@ -84,10 +84,10 @@ internal class SoPostControllerTest {
         every { soPostService.addHiddenContent(any(), any(), any(), any()) } returns Unit
         
         mockMvc.perform(
-            post("/so/posts/hidden")
+            post("/so/posts/{id}/hidden-content", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 //language=json
-                .content("{\n  \"postId\": 1,\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
+                .content("{\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
         ).andExpect(status().isCreated)
         
         verify { soPostService.addHiddenContent(1L, "question-1", "answer-1", "content-1") }
@@ -98,10 +98,10 @@ internal class SoPostControllerTest {
         every { soPostService.addHiddenContent(any(), any(), any(), any()) } throws DataConflictException()
         
         mockMvc.perform(
-            post("/so/posts/hidden")
+            post("/so/posts/{id}/hidden-content", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 //language=json
-                .content("{\n  \"postId\": 1,\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
+                .content("{\n  \"question\": \"question-1\",\n  \"answer\": \"answer-1\",\n  \"content\": \"content-1\"\n}")
         ).andExpect(status().isConflict)
         
         verify { soPostService.addHiddenContent(1L, "question-1", "answer-1", "content-1") }

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItemTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/response/SoPostResponseItemTest.kt
@@ -6,21 +6,22 @@ import study.nobreak.personalposts.so.mock.mockSoPost
 
 internal class SoPostResponseItemTest {
     @Test
-    fun `fromSoPost`() {
+    fun `fromSoPost isQuestionIncluded true`() {
         val result1 = SoPostResponseItem.fromSoPost(
             mockSoPost(
                 id = 1L,
                 title = "title-1",
                 content = "content-1"
-            )
+            ), true
         )
+        
         val result2 = SoPostResponseItem.fromSoPost(
             mockSoPost(
                 id = 2L,
                 title = "title-2",
                 content = "content-2",
                 question = "question-2"
-            )
+            ), true
         )
         
         assertEquals(1L, result1.id)
@@ -32,5 +33,35 @@ internal class SoPostResponseItemTest {
         assertEquals("title-2", result2.title)
         assertEquals("content-2", result2.content)
         assertEquals("question-2", result2.hiddenContentQuestion)
+    }
+    
+    @Test
+    fun `fromSoPost isQuestionIncluded false`() {
+        val result1 = SoPostResponseItem.fromSoPost(
+            mockSoPost(
+                id = 1L,
+                title = "title-1",
+                content = "content-1",
+                question = "question-1"
+            ), false
+        )
+        
+        val result2 = SoPostResponseItem.fromSoPost(
+            mockSoPost(
+                id = 2L,
+                title = "title-2",
+                content = "content-2"
+            ), false
+        )
+    
+        assertEquals(1L, result1.id)
+        assertEquals("title-1", result1.title)
+        assertEquals("content-1", result1.content)
+        assertEquals(null, result1.hiddenContentQuestion)
+    
+        assertEquals(2L, result2.id)
+        assertEquals("title-2", result2.title)
+        assertEquals("content-2", result2.content)
+        assertEquals(null, result2.hiddenContentQuestion)
     }
 }


### PR DESCRIPTION
* Fix api endpoint to indicate child resource
  * hidden content를 추가하는 `SoPostController.addHiddenContent` 의 url을 Restful하게 수정하였습니다.
* Add get posts with hidden question
  * 게시글을 조회하는 `SoPostController.getPosts`에 질문을 추가, 삭제할 수 있는 `isQuestionIncluded` 옵션을 추가하였습니다.
