### PR TITLE
Add pagination for get so posts

### DIFF
--- a/src/main/kotlin/study/nobreak/personalposts/so/repository/DslRepositoryExt.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/repository/DslRepositoryExt.kt
@@ -1,0 +1,15 @@
+package study.nobreak.personalposts.so.repository
+
+import com.querydsl.jpa.JPQLQuery
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+fun <T> JPQLQuery<T>.fetchPage(pageable: Pageable): Page<T> {
+    return this
+        .offset(pageable.offset)
+        .limit(pageable.pageSize.toLong())
+        .let {
+            PageImpl(it.fetch(), pageable, it.fetchCount())
+        }
+}

--- a/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package study.nobreak.personalposts.so.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
 import study.nobreak.personalposts.so.domain.QSoPost
@@ -9,13 +11,9 @@ import study.nobreak.personalposts.so.domain.SoPost
 class SoPostDslRepositoryImpl: SoPostDslRepository, QuerydslRepositorySupport(SoPost::class.java) {
     private val soPost: QSoPost = QSoPost.soPost
     
-    override fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean): List<SoPost> {
-        return if (isHiddenContentIncluded) {
-            from(soPost)
-                .leftJoin(soPost.hiddenContent).fetchJoin()
-                .fetch()
-        } else {
-            from(soPost).fetch()
-        }
+    override fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean, pageable: Pageable): Page<SoPost> {
+        return from(soPost)
+            .let { if (isHiddenContentIncluded) it.leftJoin(soPost.hiddenContent).fetchJoin() else it }
+            .fetchPage(pageable)
     }
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostRepository.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/repository/SoPostRepository.kt
@@ -1,11 +1,12 @@
 package study.nobreak.personalposts.so.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import study.nobreak.personalposts.so.domain.SoPost
 
 interface SoPostRepository: JpaRepository<SoPost, Long>, SoPostDslRepository
 
 interface SoPostDslRepository {
-    fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean): List<SoPost>
+    fun findAllByFetchJoinCondition(isHiddenContentIncluded: Boolean, pageable: Pageable): Page<SoPost>
 }
-

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostService.kt
@@ -1,10 +1,12 @@
 package study.nobreak.personalposts.so.service
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import study.nobreak.personalposts.so.domain.SoPost
 
 interface SoPostService {
     fun addPost(title: String, content: String)
-    fun getAll(isQuestionIncluded: Boolean): List<SoPost>
+    fun getAll(isQuestionIncluded: Boolean, pageable: Pageable): Page<SoPost>
     fun deletePost(id: Long)
     fun addHiddenContent(postId: Long, question: String, answer: String, content: String)
 }

--- a/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImpl.kt
@@ -1,6 +1,8 @@
 package study.nobreak.personalposts.so.service
 
 import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import study.nobreak.personalposts.so.domain.SoPost
@@ -15,8 +17,8 @@ class SoPostServiceImpl(
         soPostRepository.save(SoPost(title = title, content = content))
     }
     
-    override fun getAll(isQuestionIncluded: Boolean): List<SoPost> {
-        return soPostRepository.findAllByFetchJoinCondition(isQuestionIncluded)
+    override fun getAll(isQuestionIncluded: Boolean, pageable: Pageable): Page<SoPost> {
+        return soPostRepository.findAllByFetchJoinCondition(isQuestionIncluded, pageable)
     }
     
     override fun deletePost(id: Long) {

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/SoPostController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*
 import study.nobreak.personalposts.so.service.SoPostService
 import study.nobreak.personalposts.so.web.request.SoHiddenContentCreateRequest
 import study.nobreak.personalposts.so.web.request.SoPostCreateRequest
+import study.nobreak.personalposts.so.web.request.SoPostGetRequest
 import study.nobreak.personalposts.so.web.response.SoPostGetResponse
 import study.nobreak.personalposts.so.web.response.SoPostResponseItem
 
@@ -15,9 +16,16 @@ class SoPostController(
 ) {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    fun getPosts(@RequestParam isQuestionIncluded: Boolean = false): SoPostGetResponse {
-        return SoPostGetResponse(
-            soPostService.getAll(isQuestionIncluded).map { SoPostResponseItem.fromSoPost(it, isQuestionIncluded) })
+    fun getPosts(soPostGetRequest: SoPostGetRequest): SoPostGetResponse {
+        return soPostService.getAll(soPostGetRequest.isQuestionIncluded, soPostGetRequest.toPageable()).let { page ->
+            SoPostGetResponse(
+                content = page.content.map {
+                    SoPostResponseItem.fromSoPost(it, soPostGetRequest.isQuestionIncluded)
+                },
+                totalPages = page.totalPages,
+                totalElements = page.totalElements
+            )
+        }
     }
     
     @PostMapping

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoPageRequest.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoPageRequest.kt
@@ -1,0 +1,13 @@
+package study.nobreak.personalposts.so.web.request
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+
+interface SoPageRequest {
+    val pageNumber: Int
+    val pageSize: Int
+    
+    fun toPageable(): Pageable {
+        return PageRequest.of(pageNumber - 1, pageSize)
+    }
+}

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoPostGetRequest.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/request/SoPostGetRequest.kt
@@ -1,0 +1,7 @@
+package study.nobreak.personalposts.so.web.request
+
+data class SoPostGetRequest(
+    val isQuestionIncluded: Boolean = false,
+    override val pageNumber: Int = 1,
+    override val pageSize: Int = 10
+): SoPageRequest

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPageResponse.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPageResponse.kt
@@ -1,0 +1,7 @@
+package study.nobreak.personalposts.so.web.response
+
+interface SoPageResponse<T> {
+    val content: List<T>
+    val totalPages: Int
+    val totalElements: Long
+}

--- a/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostGetResponse.kt
+++ b/src/main/kotlin/study/nobreak/personalposts/so/web/response/SoPostGetResponse.kt
@@ -1,3 +1,7 @@
 package study.nobreak.personalposts.so.web.response
 
-data class SoPostGetResponse(val list: List<SoPostResponseItem>)
+data class SoPostGetResponse(
+    override val content: List<SoPostResponseItem>,
+    override val totalPages: Int,
+    override val totalElements: Long
+): SoPageResponse<SoPostResponseItem>

--- a/src/test/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImplTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/repository/SoPostDslRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.ActiveProfiles
 import study.nobreak.personalposts.so.domain.SoPost
 
@@ -24,17 +25,19 @@ internal class SoPostDslRepositoryImplTest @Autowired constructor(
             flush()
             clear()
         }
-        val result = soPostRepository.findAllByFetchJoinCondition(true)
+        val result = soPostRepository.findAllByFetchJoinCondition(true, PageRequest.of(0, 10))
         
-        assertEquals(result.size, 2)
-        assertEquals("title-0", result[0].title)
-        assertEquals("content-0", result[0].content)
-        assertEquals(null, result[0].hiddenContent)
-        assertEquals("title-1", result[1].title)
-        assertEquals("content-1", result[1].content)
-        assertEquals("question-1", result[1].hiddenContent!!.question)
-        assertEquals("answer-1", result[1].hiddenContent!!.answer)
-        assertEquals("hidden-content-1", result[1].hiddenContent!!.content)
+        assertEquals(10, result.size)
+        assertEquals(1, result.totalPages)
+        assertEquals(2, result.totalElements)
+        assertEquals("title-0", result.content[0].title)
+        assertEquals("content-0", result.content[0].content)
+        assertEquals(null, result.content[0].hiddenContent)
+        assertEquals("title-1", result.content[1].title)
+        assertEquals("content-1", result.content[1].content)
+        assertEquals("question-1", result.content[1].hiddenContent!!.question)
+        assertEquals("answer-1", result.content[1].hiddenContent!!.answer)
+        assertEquals("hidden-content-1", result.content[1].hiddenContent!!.content)
     }
     
     @Test
@@ -47,16 +50,18 @@ internal class SoPostDslRepositoryImplTest @Autowired constructor(
             flush()
             clear()
         }
-        val result = soPostRepository.findAllByFetchJoinCondition(false)
+        val result = soPostRepository.findAllByFetchJoinCondition(false, PageRequest.of(0, 10))
         
-        assertEquals(result.size, 2)
-        assertEquals("title-0", result[0].title)
-        assertEquals("content-0", result[0].content)
-        assertEquals(null, result[0].hiddenContent)
-        assertEquals("title-1", result[1].title)
-        assertEquals("content-1", result[1].content)
-        assertEquals("question-1", result[1].hiddenContent!!.question)
-        assertEquals("answer-1", result[1].hiddenContent!!.answer)
-        assertEquals("hidden-content-1", result[1].hiddenContent!!.content)
+        assertEquals(10, result.size)
+        assertEquals(1, result.totalPages)
+        assertEquals(2, result.totalElements)
+        assertEquals("title-0", result.content[0].title)
+        assertEquals("content-0", result.content[0].content)
+        assertEquals(null, result.content[0].hiddenContent)
+        assertEquals("title-1", result.content[1].title)
+        assertEquals("content-1", result.content[1].content)
+        assertEquals("question-1", result.content[1].hiddenContent!!.question)
+        assertEquals("answer-1", result.content[1].hiddenContent!!.answer)
+        assertEquals("hidden-content-1", result.content[1].hiddenContent!!.content)
     }
 }

--- a/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/service/SoPostServiceImplTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import study.nobreak.personalposts.so.domain.SoPost
 import study.nobreak.personalposts.so.exception.DataConflictException
 import study.nobreak.personalposts.so.exception.NoDataFoundException
@@ -40,17 +42,19 @@ internal class SoPostServiceImplTest {
     @Test
     fun `getAll success`() {
         every {
-            soPostRepository.findAllByFetchJoinCondition(true)
-        } returns listOf(
-            mockSoPost(id = 1, title = "title-1"),
-            mockSoPost(id = 2),
-            mockSoPost(id = 3),
-            mockSoPost(id = 4)
+            soPostRepository.findAllByFetchJoinCondition(true, any())
+        } returns PageImpl(
+            listOf(
+                mockSoPost(id = 1, title = "title-1"),
+                mockSoPost(id = 2),
+                mockSoPost(id = 3),
+                mockSoPost(id = 4)
+            )
         )
-        val result = soPostService.getAll(true)
+        val result = soPostService.getAll(true, PageRequest.of(1, 10))
         
         assertEquals(4, result.size)
-        assertEquals("title-1", result[0].title)
+        assertEquals("title-1", result.content[0].title)
     }
     
     @Test

--- a/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
+++ b/src/test/kotlin/study/nobreak/personalposts/so/web/SoPostControllerTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageImpl
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
@@ -26,9 +27,11 @@ internal class SoPostControllerTest {
     
     @Test
     fun `getPosts isQuestionIncluded true success`() {
-        every { soPostService.getAll(true) } returns listOf(
-            mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
-            mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
+        every { soPostService.getAll(true, any()) } returns PageImpl(
+            listOf(
+                mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
+                mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
+            )
         )
         
         mockMvc.perform(
@@ -36,31 +39,37 @@ internal class SoPostControllerTest {
                 .param("isQuestionIncluded", "true")
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.list[0].id").value("1"))
-            .andExpect(jsonPath("$.list[0].title").value("title-1"))
-            .andExpect(jsonPath("$.list[0].content").value("content-1"))
-            .andExpect(jsonPath("$.list[0].hiddenContentQuestion").value("hiddenContentQuestion-1"))
-            .andExpect(jsonPath("$.list[1].id").value("2"))
-            .andExpect(jsonPath("$.list[1].title").value("title-2"))
-            .andExpect(jsonPath("$.list[1].content").value("content-2"))
-            .andExpect(jsonPath("$.list[1].hiddenContentQuestion").value("hiddenContentQuestion-2"))
+            .andExpect(jsonPath("$.content[0].id").value("1"))
+            .andExpect(jsonPath("$.content[0].title").value("title-1"))
+            .andExpect(jsonPath("$.content[0].content").value("content-1"))
+            .andExpect(jsonPath("$.content[0].hiddenContentQuestion").value("hiddenContentQuestion-1"))
+            .andExpect(jsonPath("$.content[1].id").value("2"))
+            .andExpect(jsonPath("$.content[1].title").value("title-2"))
+            .andExpect(jsonPath("$.content[1].content").value("content-2"))
+            .andExpect(jsonPath("$.content[1].hiddenContentQuestion").value("hiddenContentQuestion-2"))
     }
     
     @Test
     fun `getPosts isQuestionIncluded default false success`() {
-        every { soPostService.getAll(false) } returns listOf(
-            mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
-            mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
+        every { soPostService.getAll(false, any()) } returns PageImpl(
+            listOf(
+                mockSoPost(id = 1, title = "title-1", content = "content-1", question = "hiddenContentQuestion-1"),
+                mockSoPost(id = 2, title = "title-2", content = "content-2", question = "hiddenContentQuestion-2")
+            )
         )
         
-        mockMvc.perform(get("/so/posts"))
+        mockMvc.perform(
+            get("/so/posts")
+                .param("pageNumber", "1")
+                .param("pageSize", "1")
+        )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.list[0].id").value("1"))
-            .andExpect(jsonPath("$.list[0].title").value("title-1"))
-            .andExpect(jsonPath("$.list[0].content").value("content-1"))
-            .andExpect(jsonPath("$.list[1].id").value("2"))
-            .andExpect(jsonPath("$.list[1].title").value("title-2"))
-            .andExpect(jsonPath("$.list[1].content").value("content-2"))
+            .andExpect(jsonPath("$.content[0].id").value("1"))
+            .andExpect(jsonPath("$.content[0].title").value("title-1"))
+            .andExpect(jsonPath("$.content[0].content").value("content-1"))
+            .andExpect(jsonPath("$.content[1].id").value("2"))
+            .andExpect(jsonPath("$.content[1].title").value("title-2"))
+            .andExpect(jsonPath("$.content[1].content").value("content-2"))
     }
     
     @Test


### PR DESCRIPTION
getSoPosts에 pagination을 적용했습니다.
`org.springframework.data.domain.Page`, `org.springframework.data.domain.Pageable` 를 사용하여 구현하였습니다.
인터페이스를 만들어 일부 조건들만 적용했습니다. 
* Request
  * `pageNumber`
  * `pageSize`
* Response
  * `content`(결과 목록 `List<T>`)
  * `totalPages`
  *  `totalElements`